### PR TITLE
[#14] - Agregar componente LinkCardComponent para navegación desde landing

### DIFF
--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -2,6 +2,10 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 
 export const serverRoutes: ServerRoute[] = [
   {
+    path: '',
+    renderMode: RenderMode.Prerender
+  },
+  {
     path: '**',
     renderMode: RenderMode.Prerender
   }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,5 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', loadComponent: () => import('./pages/home.component').then(m => m.HomeComponent) },
+];

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,4 +2,5 @@ import { Routes } from '@angular/router';
 
 export const routes: Routes = [
   { path: '', loadComponent: () => import('./pages/home.component').then(m => m.HomeComponent) },
+  { path: '**', redirectTo: '' }
 ];

--- a/src/app/components/link-card/link-card.component.ts
+++ b/src/app/components/link-card/link-card.component.ts
@@ -1,0 +1,60 @@
+import { Component, input } from '@angular/core';
+
+export interface LinkCard {
+  title: string;
+  backgroundImageUrl: string;
+}
+
+@Component({
+  selector: '[app-link-card]',
+  imports: [],
+  template: `
+    <span class="title">
+      {{ content().title }}
+    </span>
+  `,
+  styles: `
+    :host {
+      display: flex;
+      width: 100%;
+      justify-content: space-around;
+      align-items: center;
+      backdrop-filter: blur(2px);
+      flex: 1 1 0;
+
+      &:first-of-type {
+        background: linear-gradient(0deg, rgba(0, 0, 0, 0.24) 0%, rgba(0, 0, 0, 0.24) 100%), linear-gradient(0deg, rgba(238, 45, 111, 0.20) 0%, rgba(238, 45, 111, 0.20) 100%), url('/card-background.png') lightgray 50% / cover no-repeat;
+      }
+
+      &:nth-of-type(2) {
+        background: linear-gradient(0deg, rgba(0, 0, 0, 0.24) 0%, rgba(0, 0, 0, 0.24) 100%), linear-gradient(0deg, rgba(73, 116, 230, 0.20) 0%, rgba(73, 116, 230, 0.20) 100%), url('/card-background.png') lightgray 50% / cover no-repeat;
+      }
+
+      &:nth-child(3) {
+        background: linear-gradient(0deg, rgba(0, 0, 0, 0.24) 0%, rgba(0, 0, 0, 0.24) 100%), linear-gradient(0deg, rgba(230, 185, 73, 0.20) 0%, rgba(230, 185, 73, 0.20) 100%), url('/card-background.png') lightgray 50% / cover no-repeat;
+      }
+
+      &:nth-child(4) {
+        background: linear-gradient(0deg, rgba(0, 0, 0, 0.24) 0%, rgba(0, 0, 0, 0.24) 100%), linear-gradient(0deg, rgba(73, 230, 87, 0.20) 0%, rgba(73, 230, 87, 0.20) 100%), url('/card-background.png') lightgray 50% / cover no-repeat;
+      }
+
+      &:nth-child(5) {
+        background: linear-gradient(0deg, rgba(0, 0, 0, 0.24) 0%, rgba(0, 0, 0, 0.24) 100%), linear-gradient(0deg, rgba(145, 130, 94, 0.20) 0%, rgba(145, 130, 94, 0.20) 100%), url('/card-background.png') lightgray 50% / cover no-repeat;
+      }
+    }
+
+    .title {
+      color: #FFF;
+      text-align: center;
+      font-size: 24px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: normal;
+      letter-spacing: -1.2px;
+      text-transform: uppercase;
+    }
+  `
+})
+export class LinkCardComponent {
+  content = input.required<LinkCard>()
+}

--- a/src/app/pages/home.component.ts
+++ b/src/app/pages/home.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-home',
+  imports: [],
+  template: `
+    <p>
+      home works!
+    </p>
+  `,
+  styles: ``
+})
+export class HomeComponent {
+
+}

--- a/src/app/pages/home.component.ts
+++ b/src/app/pages/home.component.ts
@@ -1,15 +1,47 @@
 import { Component } from '@angular/core';
+import { LinkCard, LinkCardComponent } from '../components/link-card/link-card.component'
 
 @Component({
   selector: 'app-home',
-  imports: [],
+  imports: [
+    LinkCardComponent
+  ],
   template: `
-    <p>
-      home works!
-    </p>
+    @for(link of links; track $index){
+      <a app-link-card [content]="link"></a>
+    }
   `,
-  styles: ``
+  styles: `
+    :host {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      height: 100%;
+      padding: 16px;
+    }`
 })
 export class HomeComponent {
+  links: LinkCard[] = [
+    {
+      title: 'Último capítulo',
+      backgroundImageUrl: 'card-background.png'
+    },
+    {
+      title: 'RRSS',
+      backgroundImageUrl: 'card-background.png'
+    },
+    {
+      title: 'Tienda',
+      backgroundImageUrl: 'card-background.png'
+    },
+    {
+      title: 'Wiki',
+      backgroundImageUrl: 'card-background.png'
+    },
+    {
+      title: 'Búsqueda episodios',
+      backgroundImageUrl: 'card-background.png'
+    },
 
+  ]
 }


### PR DESCRIPTION
## Resumen
Agrega:
- Página home, con la correspondiente navegación desde `app.routes.ts`
- Componente `LinkCardComponent`, orientado a visualizar la información de los links navegables desde la landing page.
- Se agrega la lista de tarjetas acorde a lo definido en los requerimientos preliminares.

## Screenshot
![image](https://github.com/user-attachments/assets/594f4f54-624e-46b5-9473-b2cab5e09675)
